### PR TITLE
Update support_functions.py

### DIFF
--- a/scripts/support_functions.py
+++ b/scripts/support_functions.py
@@ -143,7 +143,7 @@ class HRUParameters():
                 logging.error(
                     '\nWARNING: {} does not appear to have the {} cellsize '
                     'specified in the INI file\n  This may be a rounding '
-                    'issue.'.format(os.path.basename(self.polygon_path, self.cs)))
+                    'issue.'.format(os.path.basename(self.polygon_path), self.cs))
                 logging.debug('  Cols: {}\m  Rows: {}'.format(self.cols, self.rows))
                 raw_input('Press ENTER to continue')
             # Round to the nearest integer


### PR DESCRIPTION
syntax fix to warning message formatting on line 146 - the warning message formatting threw an error when we were trying to use our own grid (not the generated fishnet) that has rounding errors