### PR TITLE
update PRISM version

### DIFF
--- a/scripts/prism_4km_normals.py
+++ b/scripts/prism_4km_normals.py
@@ -146,7 +146,7 @@ def prism_4km_parameters(config_path, data_name='ALL'):
     for data_name in data_name_list:
         logging.info('\n{}'.format(data_name))
         prism_normal_re = re.compile(
-            'PRISM_(?P<type>%s)_30yr_normal_4kmM2_(?P<month>\d{2})_bil.bil$' % data_name,
+            'PRISM_(?P<type>%s)_30yr_normal_4kmM3_(?P<month>\d{2})_bil.bil$' % data_name,
             re.IGNORECASE)
 
         # Search all files & subfolders in prism folder
@@ -199,7 +199,7 @@ def prism_4km_parameters(config_path, data_name='ALL'):
             # input_name = 'PRISM_{}_30yr_normal_4kmM2_{1}_bil.bil'.format(
             #    data_name.lower(), input_month)
             # input_raster = os.path.join(input_ws, input_name)
-            output_name = 'PRISM_{}_30yr_normal_4kmM2_{}.img'.format(
+            output_name = 'PRISM_{}_30yr_normal_4kmM3_{}.img'.format(
                 data_name.lower(), month)
             output_raster = os.path.join(output_ws, output_name)
 

--- a/scripts/prism_800m_normals.py
+++ b/scripts/prism_800m_normals.py
@@ -146,7 +146,7 @@ def prism_800m_parameters(config_path, data_name='ALL'):
     for data_name in data_name_list:
         logging.info('\n{}'.format(data_name))
         prism_normal_re = re.compile(
-            'PRISM_(?P<type>%s)_30yr_normal_800mM2_(?P<month>\d{2})_bil.bil$' % data_name,
+            'PRISM_(?P<type>%s)_30yr_normal_800mM3_(?P<month>\d{2})_bil.bil$' % data_name,
             re.IGNORECASE)
 
         # Search all files & subfolders in prism folder
@@ -200,7 +200,7 @@ def prism_800m_parameters(config_path, data_name='ALL'):
             # input_name = 'PRISM_{}_30yr_normal_800mM2_{1}_bil.bil'.format(
             #    data_name.lower(), input_month)
             # input_raster = os.path.join(input_ws, input_name)
-            output_name = 'PRISM_{}_30yr_normal_800mM2_{}.img'.format(
+            output_name = 'PRISM_{}_30yr_normal_800mM3_{}.img'.format(
                 data_name.lower(), month)
             output_raster = os.path.join(output_ws, output_name)
 


### PR DESCRIPTION
PRISM was updated and files from the download site went from e.g., PRISM_ppt_30yr_normal_4kmM2_01_bil.bil to PRISM_ppt_30yr_normal_4kmM3_01_bil.bil, breaking the regex matching in the two prism scripts.